### PR TITLE
Cached title

### DIFF
--- a/src/BreadcrumbTagHelper.cs
+++ b/src/BreadcrumbTagHelper.cs
@@ -49,7 +49,9 @@ namespace SmartBreadcrumbs
 
             if (node != null)
             {
-                sb.Append($"<li class=\"{_breadcrumbsManager.Options.ActiveLiClasses}\">{ExtractTitle(node.Title)}</li>");
+               node.Title = ExtractTitle(node.Title);
+               sb.Append($"<li class=\"{_breadcrumbsManager.Options.ActiveLiClasses}\">{node.Title}</li>");
+
 
                 while (node.Parent != null)
                 {


### PR DESCRIPTION
If you use ViewData.Title on an action, Then on a subaction reference the parent action with FromAction the node title is "ViewData.Title" not the translated value. i changed it so when the Breadcrumb node i processed the title is updated, and cached for later use.