### PR TITLE
Fix IActionContextAccessor DI registration

### DIFF
--- a/src/BreadcrumbExtensions.cs
+++ b/src/BreadcrumbExtensions.cs
@@ -26,7 +26,7 @@ namespace SmartBreadcrumbs
             var bm = new BreadcrumbsManager();
             bm.Initialize(assembly, options);
             services.AddSingleton(bm);
-            services.TryAddScoped<IActionContextAccessor, ActionContextAccessor>();
+            services.TryAddSingleton<IActionContextAccessor, ActionContextAccessor>();
         }
 
     }


### PR DESCRIPTION
Hello! 

I'm using your utility-library with latest Asp.Net Core 2.1 and get fatal error all time when start application. The problem with register IActionContextAccessor: 

> InvalidOperationException: Cannot consume scoped service 'Microsoft.AspNetCore.Mvc.Infrastructure.IActionContextAccessor'.

Because IActionContextAccessor should be resolving as Singleton like IHttpContextAccessor. Look [this commit](https://github.com/aspnet/HttpAbstractions/pull/947) for services.AddHttpContextAccessor() method.

So it should be 
`services.TryAddSingleton<IActionContextAccessor, ActionContextAccessor>();`