### PR TITLE
Fixes #23 ArgumentException When Decorating Action Overload(s)

### DIFF
--- a/examples/RazorPagesAndMvc/Controllers/Java/AdvancedJavaController.cs
+++ b/examples/RazorPagesAndMvc/Controllers/Java/AdvancedJavaController.cs
@@ -6,13 +6,21 @@ namespace RazorPagesAndMvc.Controllers.Java
     [Route("Java/Advanced/[action]")]
     public class AdvancedJavaController : Controller
     {
-
+        [HttpGet]
         [Breadcrumb("Advanced", FromAction = "Index", FromController = typeof(JavaController))]
         public IActionResult Index()
         {
             return View();
         }
 
+        [HttpPost]
+        [Breadcrumb("Advanced", FromAction = "Index", FromController = typeof(JavaController))]
+        public IActionResult Index(int i)
+        {
+            return View();
+        }
+
+        [HttpGet]
         [Breadcrumb("Post 1", FromAction = "Index")]
         public IActionResult Post1()
         {

--- a/src/Attributes/BreadcrumbAttribute.cs
+++ b/src/Attributes/BreadcrumbAttribute.cs
@@ -4,6 +4,7 @@ using SmartBreadcrumbs.Extensions;
 
 namespace SmartBreadcrumbs.Attributes
 {
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class BreadcrumbAttribute : Attribute
     {
 
@@ -67,6 +68,13 @@ namespace SmartBreadcrumbs.Attributes
 
         public virtual string ExtractFromKey(Type type)
         {
+            //Check if type is a controller without a FromAction
+            if (type.IsController() && string.IsNullOrWhiteSpace(FromAction) && FromController != null)
+            {
+                //should only come here if type is a controller and attribute is placed at controller class level
+                return FromController.ExtractMvcControllerKey();
+            }
+
             if (!string.IsNullOrWhiteSpace(FromAction))
             {
                 var fromControllerType = FromController;

--- a/src/Attributes/BreadcrumbAttribute.cs
+++ b/src/Attributes/BreadcrumbAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using SmartBreadcrumbs.Extensions;
 
@@ -91,7 +92,9 @@ namespace SmartBreadcrumbs.Attributes
                 if (!fromControllerType.IsController())
                     throw new SmartBreadcrumbsException($"'{fromControllerType.Name}' is used in FromController but isn't a Controller.");
 
-                var actionMethod = fromControllerType.GetMethod(FromAction, BindingFlags.Instance | BindingFlags.Public);
+                var actionMethod = fromControllerType.GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                    .FirstOrDefault(m=>m.Name == FromAction); //to prevent AmbiguousMatchException
+
                 if (actionMethod == null || actionMethod.ReturnType.IsAction() == false)
                     throw new SmartBreadcrumbsException($"{fromControllerType.Name} doesn't contain a valid action named {FromAction}.");
 

--- a/src/BreadcrumbOptions.cs
+++ b/src/BreadcrumbOptions.cs
@@ -50,6 +50,11 @@
 
         public bool HasSeparatorElement => !string.IsNullOrEmpty(SeparatorElement);
 
+        /// <summary>
+        /// The action to call when only a controller is known, e.g. nameof(HomeController.Index).
+        /// </summary>
+        public string DefaultAction { get; }
+
         #endregion
 
         public BreadcrumbOptions()
@@ -58,9 +63,10 @@
             OlClasses = "breadcrumb";
             LiClasses = "breadcrumb-item";
             ActiveLiClasses = "breadcrumb-item active";
+            DefaultAction = "Index";
         }
 
-        public BreadcrumbOptions(string tagName, string olClasses, string liClasses, string activeLiClasses, string tagClasses = null, string separatorElement = null)
+        public BreadcrumbOptions(string tagName, string olClasses, string liClasses, string activeLiClasses, string tagClasses = null, string separatorElement = null, string defaultAction = "Index")
         {
             TagName = tagName;
             OlClasses = olClasses;
@@ -68,6 +74,7 @@
             ActiveLiClasses = activeLiClasses;
             TagClasses = tagClasses;
             SeparatorElement = separatorElement;
+            DefaultAction = defaultAction;
         }
 
     }

--- a/src/BreadcrumbTagHelper.cs
+++ b/src/BreadcrumbTagHelper.cs
@@ -45,15 +45,15 @@ namespace SmartBreadcrumbs
             string nodeKey = GetNodeKey(ViewContext.ActionDescriptor.RouteValues);
             var node = ViewContext.ViewData["BreadcrumbNode"] as BreadcrumbNode ?? _breadcrumbManager.GetNode(nodeKey);
 
-            output.TagName = _breadcrumbManager.Options.TagName;
+            output.TagName = BreadcrumbManager.Options.TagName;
 
             // Tag Classes
-            if (!string.IsNullOrEmpty(_breadcrumbManager.Options.TagClasses))
+            if (!string.IsNullOrEmpty(BreadcrumbManager.Options.TagClasses))
             {
-                output.Attributes.Add("class", _breadcrumbManager.Options.TagClasses);
+                output.Attributes.Add("class", BreadcrumbManager.Options.TagClasses);
             }
 
-            output.Content.AppendHtml($"<ol class=\"{_breadcrumbManager.Options.OlClasses}\">");
+            output.Content.AppendHtml($"<ol class=\"{BreadcrumbManager.Options.OlClasses}\">");
 
             var sb = new StringBuilder();
 
@@ -70,9 +70,9 @@ namespace SmartBreadcrumbs
                     node = node.Parent;
 
                     // Separator
-                    if (_breadcrumbManager.Options.HasSeparatorElement)
+                    if (BreadcrumbManager.Options.HasSeparatorElement)
                     {
-                        sb.Insert(0, _breadcrumbManager.Options.SeparatorElement);
+                        sb.Insert(0, BreadcrumbManager.Options.SeparatorElement);
                     }
 
                     sb.Insert(0, GetLi(node, node.GetUrl(_urlHelper), false));
@@ -83,9 +83,9 @@ namespace SmartBreadcrumbs
             if (node != _breadcrumbManager.DefaultNode)
             {
                 // Separator
-                if (_breadcrumbManager.Options.HasSeparatorElement)
+                if (BreadcrumbManager.Options.HasSeparatorElement)
                 {
-                    sb.Insert(0, _breadcrumbManager.Options.SeparatorElement);
+                    sb.Insert(0, BreadcrumbManager.Options.SeparatorElement);
                 }
 
                 sb.Insert(0, GetLi(_breadcrumbManager.DefaultNode,
@@ -104,9 +104,12 @@ namespace SmartBreadcrumbs
 
         private string GetNodeKey(IDictionary<string, string> routeValues)
         {
-            return routeValues.ContainsKey("page") && !string.IsNullOrWhiteSpace(routeValues["page"]) ?
-                routeValues["page"] :
-                $"{routeValues["controller"]}.{routeValues["action"]}";
+            if (routeValues.ContainsKey("page") && !string.IsNullOrWhiteSpace(routeValues["page"]))
+                return routeValues["page"];
+            else if (routeValues.ContainsKey("controller") && !routeValues.ContainsKey("action"))
+                return $"{routeValues["controller"]}";
+
+            return $"{routeValues["controller"]}.{routeValues["action"]}";
         }
 
         private string ExtractTitle(string title)
@@ -128,14 +131,14 @@ namespace SmartBreadcrumbs
             // In case the node's title is still ViewData.Something
             string nodeTitle = ExtractTitle(node.Title);
 
-            var normalTemplate = _breadcrumbManager.Options.LiTemplate;
-            var activeTemplate = _breadcrumbManager.Options.ActiveLiTemplate;
+            var normalTemplate = BreadcrumbManager.Options.LiTemplate;
+            var activeTemplate = BreadcrumbManager.Options.ActiveLiTemplate;
 
             if (!isActive && string.IsNullOrEmpty(normalTemplate))
-                return $"<li{GetClass(_breadcrumbManager.Options.LiClasses)}><a href=\"{link}\">{nodeTitle}</a></li>";
+                return $"<li{GetClass(BreadcrumbManager.Options.LiClasses)}><a href=\"{link}\">{nodeTitle}</a></li>";
 
             if (isActive && string.IsNullOrEmpty(activeTemplate))
-                return $"<li{GetClass(_breadcrumbManager.Options.LiClasses)}>{nodeTitle}</li>";
+                return $"<li{GetClass(BreadcrumbManager.Options.LiClasses)}>{nodeTitle}</li>";
 
             // Templates
             string templateToUse = isActive ? activeTemplate : normalTemplate;

--- a/src/BreadcrumbTagHelper.cs
+++ b/src/BreadcrumbTagHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -109,6 +110,10 @@ namespace SmartBreadcrumbs
             else if (routeValues.ContainsKey("controller") && !routeValues.ContainsKey("action"))
                 return $"{routeValues["controller"]}";
 
+            if (!HttpMethods.IsGet(ViewContext.HttpContext.Request.Method))
+            {
+                return $"{routeValues["controller"]}.{routeValues["action"]}#{ViewContext.HttpContext.Request.Method}";
+            }
             return $"{routeValues["controller"]}.{routeValues["action"]}";
         }
 

--- a/src/Extensions/ReflectionExtensions.cs
+++ b/src/Extensions/ReflectionExtensions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
 
 namespace SmartBreadcrumbs.Extensions
 {
@@ -26,6 +29,11 @@ namespace SmartBreadcrumbs.Extensions
 
         public static bool IsAction(this Type type)
             => type != null && (ActionResultType.IsAssignableFrom(type) || ActionResultTaskType.IsAssignableFrom(type));
+
+        public static IEnumerable<string> ExtractHttpMethodAttributes(this MethodInfo actionMethod)
+            => actionMethod.GetCustomAttributes<HttpMethodAttribute>(true)
+                .SelectMany(m => m.HttpMethods)
+                .Distinct();
 
         public static string ExtractRazorPageKey(this Type pageType)
         {

--- a/src/Extensions/ReflectionExtensions.cs
+++ b/src/Extensions/ReflectionExtensions.cs
@@ -53,5 +53,12 @@ namespace SmartBreadcrumbs.Extensions
             return $"{controllerType.Name.Replace("Controller", "")}.{actionMethod.Name}";
         }
 
+        public static string ExtractMvcControllerKey(this Type controllerType)
+        {
+            if (controllerType == null)
+                throw new ArgumentNullException(nameof(controllerType));
+
+            return $"{controllerType.Name.Replace("Controller", "")}.{BreadcrumbManager.Options.DefaultAction}";
+        }
     }
 }

--- a/src/Nodes/MvcControllerBreadcrumbNode.cs
+++ b/src/Nodes/MvcControllerBreadcrumbNode.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using SmartBreadcrumbs.Attributes;
+
+namespace SmartBreadcrumbs.Nodes
+{
+    public class MvcControllerBreadcrumbNode : BreadcrumbNode
+    {
+        #region Properties
+        public string Controller { get; set; }
+
+        #endregion
+
+        internal MvcControllerBreadcrumbNode(string controller, BreadcrumbAttribute attr) : base(attr)
+        {
+            Controller = controller;
+        }
+
+        public MvcControllerBreadcrumbNode(string controller, string title, bool overwriteTitleOnExactMatch = false, string iconClasses = null, string areaName = null)
+            : base(title, overwriteTitleOnExactMatch, iconClasses, areaName)
+        {
+            Controller = controller;
+        }
+
+        #region Public Methods
+        public override string GetUrl(IUrlHelper urlHelper) => urlHelper.Action(new UrlActionContext() { Action = BreadcrumbManager.Options.DefaultAction, Controller = Controller, Values = RouteValues });
+        #endregion
+    }
+}

--- a/tests/SmartBreadcrumbs.UnitTests/BreadcrumbAttributeTests.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/BreadcrumbAttributeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using SmartBreadcrumbs.Attributes;
 using SmartBreadcrumbs.UnitTests.Pages;
 using SmartBreadcrumbs.UnitTests.Pages.SubFolder1;
@@ -88,5 +89,69 @@ namespace SmartBreadcrumbs.UnitTests
             Assert.Equal(expectedFromKey, attr.ExtractFromKey(null));
         }
 
+        [Fact]
+        public void GetNode_ShouldNotReturnNull_WhenAttributeOnControllerIsUsed()
+        {
+            var bm = new BreadcrumbManager(new BreadcrumbOptions());
+            bm.Initialize(GetType().Assembly);
+
+            var node = bm.GetNode($"Main.{BreadcrumbManager.Options.DefaultAction}");
+
+            Assert.NotNull(node);
+        }
+
+        [Fact]
+        public void GetNode_ShouldNotHaveParent_WhenDefaultAttributeOnControllerIsUsed()
+        {
+            var bm = new BreadcrumbManager(new BreadcrumbOptions());
+            bm.Initialize(GetType().Assembly);
+
+            var node = bm.GetNode($"Main.{BreadcrumbManager.Options.DefaultAction}");
+
+            Assert.Null(node.Parent);
+        }
+
+        [Fact]
+        public void GetNode_ShouldHaveParent_WhenNonDefaultAttributeUsedOnController()
+        {
+            var bm = new BreadcrumbManager(new BreadcrumbOptions());
+            bm.Initialize(GetType().Assembly);
+
+            var node = bm.GetNode($"Second.{BreadcrumbManager.Options.DefaultAction}");
+            var parentNode = node.Parent;
+
+            Assert.NotNull(parentNode);
+            Assert.Equal("Main", parentNode.Title);
+        }
+
+        [Fact]
+        public void GetNode_ShouldHaveParentThatIsDefault_WhenNonDefaultAttributeUsedOnController()
+        {
+            var bm = new BreadcrumbManager(new BreadcrumbOptions());
+            bm.Initialize(GetType().Assembly);
+
+            var node = bm.GetNode($"Second.{BreadcrumbManager.Options.DefaultAction}");
+            var parentNode = node.Parent;
+
+            Assert.Equal($"Main", parentNode.Title);
+        }
+
+        [Fact]
+        public void GetNode_ShouldHaveMultiParents_WhenNonDefaultAttributeUsedOnAction()
+        {
+            var bm = new BreadcrumbManager(new BreadcrumbOptions());
+            bm.Initialize(GetType().Assembly);
+
+            var node = bm.GetNode("Second.About");
+            var parentNode = node.Parent;
+
+            Assert.NotNull(parentNode);
+            Assert.Equal("Second", parentNode.Title);
+
+            var grandParentNode = parentNode.Parent;
+
+            Assert.NotNull(grandParentNode);
+            Assert.Equal("Main", grandParentNode.Title);
+        }
     }
 }

--- a/tests/SmartBreadcrumbs.UnitTests/ReflectionExtensionsTests.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/ReflectionExtensionsTests.cs
@@ -84,6 +84,26 @@ namespace SmartBreadcrumbs.UnitTests
 
         #endregion
 
+        #region ExtractMvcControllerKey
+
+        [Fact]
+        public void ExtractMvcControllerKey_ShouldThrowArgumentNullException_WhenControllerTypeIsNull()
+        {
+            Type type = null;
+            Assert.Throws<ArgumentNullException>(() => type.ExtractMvcControllerKey());
+        }
+
+        [Theory]
+        [InlineData(typeof(TestController), "Test")]
+        [InlineData(typeof(TestTwoController), "TestTwo")]
+        public void ExtractMvcControllerKey_ShouldReturnCorrectValue(Type fromController, string expectedKey)
+        {
+            var defaultAction = new BreadcrumbOptions().DefaultAction;
+            Assert.Equal($"{expectedKey}.{defaultAction}", fromController.ExtractMvcControllerKey());
+        }
+
+        #endregion
+
         #region ExtractMvcKey
 
         [Fact]

--- a/tests/SmartBreadcrumbs.UnitTests/TestControllers.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/TestControllers.cs
@@ -1,7 +1,44 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using SmartBreadcrumbs.Attributes;
 
 namespace SmartBreadcrumbs.UnitTests
 {
+    [DefaultBreadcrumb]
+    public class MainController : Controller
+    {
+        public IActionResult Index()
+        {
+            return Ok();
+        }
+
+        [Breadcrumb]
+        public IActionResult Privacy()
+        {
+            return Ok();
+        }
+    }
+
+    [Breadcrumb]
+    public class SecondController : Controller
+    {
+        public IActionResult Index()
+        {
+            return Ok();
+        }
+
+        [Breadcrumb(FromAction = nameof(MainController.Privacy), FromController = typeof(MainController))]
+        public IActionResult Privacy()
+        {
+            return Ok();
+        }
+
+        [Breadcrumb]
+        public IActionResult About()
+        {
+            return Ok();
+        }
+    }
+
     public class TestController : Controller
     {
 


### PR DESCRIPTION
allows identical methodnames as long as they differ in httpmethod, assumes GET is the default, otherwise looks at httpmethodAttributes.