### PR TITLE
Feature listtag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ You can specify options when you initialize SmartBreadcrumbs:
 ```cs
 services.AddBreadcrumbs(GetType().Assembly, options =>
 {
-	options.TagName = "nav";
-	options.TagClasses = "";
-	options.OlClasses = "breadcrumb";
-	options.LiClasses = "breadcrumb-item";
-	options.ActiveLiClasses = "breadcrumb-item active";
+	options.ParentTagName = "nav";
+	options.ParentTagClasses = "";
+	options.ListTagName = "ul";
+	options.ListTagClasses = "breadcrumb";
+	options.ListItemClasses = "breadcrumb-item";
+	options.ActiveListItemClasses = "breadcrumb-item active";
 	options.SeparatorElement = "<li class=\"separator\">/</li>";
 });
 ```

--- a/src/BreadcrumbManager.cs
+++ b/src/BreadcrumbManager.cs
@@ -11,10 +11,9 @@ namespace SmartBreadcrumbs
 {
     public class BreadcrumbManager
     {
-
         #region Fields
 
-        private readonly Dictionary<string, BreadcrumbNode> _nodes;
+        private readonly Dictionary<string, BreadcrumbNode> _nodes = new Dictionary<string, BreadcrumbNode>();
 
         #endregion
 
@@ -28,7 +27,6 @@ namespace SmartBreadcrumbs
 
         public BreadcrumbManager(BreadcrumbOptions options)
         {
-            _nodes = new Dictionary<string, BreadcrumbNode>();
             Options = options;
         }
 
@@ -123,6 +121,7 @@ namespace SmartBreadcrumbs
 
             return true;
         }
+
         private bool TryGetBreadcrumbNodeEntry(Type type, out BreadcrumbNodeEntry entry)
         {
             entry = null;
@@ -147,6 +146,7 @@ namespace SmartBreadcrumbs
 
             return true;
         }
+
         private IEnumerable<BreadcrumbNodeEntry> TryExtractingEntries(Type type)
         {
             if (!type.IsController())
@@ -200,17 +200,15 @@ namespace SmartBreadcrumbs
                             Default = attr.Default
                         };
                     }
-                }                
+                }
             }
         }
 
         #endregion
-
     }
 
     internal class BreadcrumbNodeEntry
     {
-
         public string Key { get; set; }
 
         public BreadcrumbNode Node { get; set; }
@@ -218,6 +216,5 @@ namespace SmartBreadcrumbs
         public string FromKey { get; set; }
 
         public bool Default { get; set; }
-
     }
 }

--- a/src/BreadcrumbOptions.cs
+++ b/src/BreadcrumbOptions.cs
@@ -2,33 +2,37 @@
 {
     public class BreadcrumbOptions
     {
-
         #region Properties
 
         /// <summary>
         /// The parent element tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string ParentTagName { get; set; }
 
         /// <summary>
         /// The parent element tag classes (seperated by a space).
         /// </summary>
-        public string TagClasses { get; set; }
+        public string ParentTagClasses { get; set; }
 
         /// <summary>
-        /// The classes of OL elements.
+        /// The list element tag name. Either 'ol' for an ordered list, or 'ul' for an unordered list.
         /// </summary>
-        public string OlClasses { get; set; }
+        public string ListTagName { get; set; }
 
         /// <summary>
-        /// The classes of LI elements.
+        /// The list element tag classes (separated by a space).
         /// </summary>
-        public string LiClasses { get; set; }
+        public string ListTagClasses { get; set; }
 
         /// <summary>
-        /// The classes of the active LI element.
+        /// The classes of the LI element (separated by a space).
         /// </summary>
-        public string ActiveLiClasses { get; set; }
+        public string ListItemClasses { get; set; }
+
+        /// <summary>
+        /// The classes of the active LI element (separated by a space).
+        /// </summary>
+        public string ActiveListItemClasses { get; set; }
 
         /// <summary>
         /// In case you want to insert a seperator element between items.\n
@@ -40,13 +44,13 @@
         /// Example: &lt;li&gt;&lt;a href="{1}"&gt;{0}&lt;/a&gt;&lt;/li&gt;
         /// <para>PS: IconClasses will have an index of 2.</para>
         /// </summary>
-        public string LiTemplate { get; set; }
+        public string ListItemTemplate { get; set; }
 
         /// <summary>
         /// Example: &lt;li class="active"&gt;&lt;a href="{1}"&gt;{0}&lt;/a&gt;&lt;/li&gt;
         /// <para>PS: IconClasses will have an index of 2.</para>
         /// </summary>
-        public string ActiveLiTemplate { get; set; }
+        public string ActiveListItemTemplate { get; set; }
 
         /// <summary>
         /// Set to true if you don't want to have a default node in your project.
@@ -66,23 +70,23 @@
 
         public BreadcrumbOptions()
         {
-            TagName = "nav";
-            OlClasses = "breadcrumb";
-            LiClasses = "breadcrumb-item";
-            ActiveLiClasses = "breadcrumb-item active";
+            ParentTagName = "nav";
+            ListTagClasses = "breadcrumb";
+            ListItemClasses = "breadcrumb-item";
+            ActiveListItemClasses = "breadcrumb-item active";
             DefaultAction = "Index";
         }
 
-        public BreadcrumbOptions(string tagName, string olClasses, string liClasses, string activeLiClasses, string tagClasses = null, string separatorElement = null, string defaultAction = "Index")
+        public BreadcrumbOptions(string parentTagName, string listTagName, string listClasses, string listItemClasses, string activeListItemClasses, string parentTagClasses = null, string separatorElement = null, string defaultAction = "Index")
         {
-            TagName = tagName;
-            OlClasses = olClasses;
-            LiClasses = liClasses;
-            ActiveLiClasses = activeLiClasses;
-            TagClasses = tagClasses;
+            ParentTagName = parentTagName;
+            ListTagName = listTagName;
+            ListTagClasses = listClasses;
+            ListItemClasses = listItemClasses;
+            ActiveListItemClasses = activeListItemClasses;
+            ParentTagClasses = parentTagClasses;
             SeparatorElement = separatorElement;
             DefaultAction = defaultAction;
         }
-
     }
 }

--- a/src/BreadcrumbOptions.cs
+++ b/src/BreadcrumbOptions.cs
@@ -2,33 +2,37 @@
 {
     public class BreadcrumbOptions
     {
-
         #region Properties
 
         /// <summary>
         /// The parent element tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string ParentTagName { get; set; }
 
         /// <summary>
         /// The parent element tag classes (seperated by a space).
         /// </summary>
-        public string TagClasses { get; set; }
+        public string ParentTagClasses { get; set; }
+
+        /// <summary>
+        /// The list element tag name. Either 'ol' for an ordered list, or 'ul' for an unordered list.
+        /// </summary>
+        public string ListTagName { get; set; }
 
         /// <summary>
         /// The classes of OL elements.
         /// </summary>
-        public string OlClasses { get; set; }
+        public string ListTagClasses { get; set; }
 
         /// <summary>
         /// The classes of LI elements.
         /// </summary>
-        public string LiClasses { get; set; }
+        public string ListItemClasses { get; set; }
 
         /// <summary>
         /// The classes of the active LI element.
         /// </summary>
-        public string ActiveLiClasses { get; set; }
+        public string ActiveListItemClasses { get; set; }
 
         /// <summary>
         /// In case you want to insert a seperator element between items.\n
@@ -40,13 +44,13 @@
         /// Example: &lt;li&gt;&lt;a href="{1}"&gt;{0}&lt;/a&gt;&lt;/li&gt;
         /// <para>PS: IconClasses will have an index of 2.</para>
         /// </summary>
-        public string LiTemplate { get; set; }
+        public string ListItemTemplate { get; set; }
 
         /// <summary>
         /// Example: &lt;li class="active"&gt;&lt;a href="{1}"&gt;{0}&lt;/a&gt;&lt;/li&gt;
         /// <para>PS: IconClasses will have an index of 2.</para>
         /// </summary>
-        public string ActiveLiTemplate { get; set; }
+        public string ActiveListItemTemplate { get; set; }
 
         /// <summary>
         /// Set to true if you don't want to have a default node in your project.
@@ -66,23 +70,23 @@
 
         public BreadcrumbOptions()
         {
-            TagName = "nav";
-            OlClasses = "breadcrumb";
-            LiClasses = "breadcrumb-item";
-            ActiveLiClasses = "breadcrumb-item active";
+            ParentTagName = "nav";
+            ListTagClasses = "breadcrumb";
+            ListItemClasses = "breadcrumb-item";
+            ActiveListItemClasses = "breadcrumb-item active";
             DefaultAction = "Index";
         }
 
-        public BreadcrumbOptions(string tagName, string olClasses, string liClasses, string activeLiClasses, string tagClasses = null, string separatorElement = null, string defaultAction = "Index")
+        public BreadcrumbOptions(string parentTagName, string listTagName, string listClasses, string listItemClasses, string activeListItemClasses, string parentTagClasses = null, string separatorElement = null, string defaultAction = "Index")
         {
-            TagName = tagName;
-            OlClasses = olClasses;
-            LiClasses = liClasses;
-            ActiveLiClasses = activeLiClasses;
-            TagClasses = tagClasses;
+            ParentTagName = parentTagName;
+            ListTagName = listTagName;
+            ListTagClasses = listClasses;
+            ListItemClasses = listItemClasses;
+            ActiveListItemClasses = activeListItemClasses;
+            ParentTagClasses = parentTagClasses;
             SeparatorElement = separatorElement;
             DefaultAction = defaultAction;
         }
-
     }
 }

--- a/src/BreadcrumbTagHelper.cs
+++ b/src/BreadcrumbTagHelper.cs
@@ -15,7 +15,6 @@ namespace SmartBreadcrumbs
     [HtmlTargetElement("breadcrumb")]
     public class BreadcrumbTagHelper : TagHelper
     {
-
         #region Fields
 
         private readonly BreadcrumbManager _breadcrumbManager;
@@ -46,15 +45,20 @@ namespace SmartBreadcrumbs
             string nodeKey = GetNodeKey(ViewContext.ActionDescriptor.RouteValues);
             var node = ViewContext.ViewData["BreadcrumbNode"] as BreadcrumbNode ?? _breadcrumbManager.GetNode(nodeKey);
 
-            output.TagName = BreadcrumbManager.Options.TagName;
+            output.TagName = BreadcrumbManager.Options.ParentTagName;
 
             // Tag Classes
-            if (!string.IsNullOrEmpty(BreadcrumbManager.Options.TagClasses))
+            if (!string.IsNullOrEmpty(BreadcrumbManager.Options.ParentTagClasses))
             {
-                output.Attributes.Add("class", BreadcrumbManager.Options.TagClasses);
+                output.Attributes.Add("class", BreadcrumbManager.Options.ParentTagClasses);
             }
 
-            output.Content.AppendHtml($"<ol class=\"{BreadcrumbManager.Options.OlClasses}\">");
+            if (string.IsNullOrEmpty(BreadcrumbManager.Options.ListTagClasses))
+            {
+                output.Content.AppendHtml($"<{BreadcrumbManager.Options.ListTagName}>");
+            } else {
+                output.Content.AppendHtml($"<{BreadcrumbManager.Options.ListTagName} class=\"{BreadcrumbManager.Options.ListTagClasses}\">");
+            }
 
             var sb = new StringBuilder();
 
@@ -96,7 +100,7 @@ namespace SmartBreadcrumbs
 
             output.Content.AppendHtml(sb.ToString());
             output.Content.AppendHtml(child);
-            output.Content.AppendHtml("</ol>");
+            output.Content.AppendHtml($"</{BreadcrumbManager.Options.ListTagName}>");
         }
 
         #endregion
@@ -135,14 +139,14 @@ namespace SmartBreadcrumbs
             // In case the node's title is still ViewData.Something
             string nodeTitle = ExtractTitle(node.Title);
 
-            var normalTemplate = BreadcrumbManager.Options.LiTemplate;
-            var activeTemplate = BreadcrumbManager.Options.ActiveLiTemplate;
+            var normalTemplate = BreadcrumbManager.Options.ListItemTemplate;
+            var activeTemplate = BreadcrumbManager.Options.ActiveListItemTemplate;
 
             if (!isActive && string.IsNullOrEmpty(normalTemplate))
-                return $"<li{GetClass(BreadcrumbManager.Options.LiClasses)}><a href=\"{link}\">{nodeTitle}</a></li>";
+                return $"<li{GetClass(BreadcrumbManager.Options.ListItemClasses)}><a href=\"{link}\">{nodeTitle}</a></li>";
 
             if (isActive && string.IsNullOrEmpty(activeTemplate))
-                return $"<li{GetClass(BreadcrumbManager.Options.ActiveLiClasses)}>{nodeTitle}</li>";
+                return $"<li{GetClass(BreadcrumbManager.Options.ActiveListItemClasses)}>{nodeTitle}</li>";
 
             // Templates
             string templateToUse = isActive ? activeTemplate : normalTemplate;


### PR DESCRIPTION
The motivation for this change was that my CSS framework of choice (Bulma.io) uses unordered lists for breadcrumbs and I couldn't change this behaviour in the options.

Also, the `class` attribute was always applied to the list element, even if there were no classes.

I made some changes to the public interface by providing more verbose property names to make the API easier to comprehend.

---
I'm sorry for any mistakes made while pushing the code up in the fork.