### PR TITLE
Added possibility for assigning RazorPagesRootDirectory through BreadcrumbOptions

### DIFF
--- a/src/BreadcrumbOptions.cs
+++ b/src/BreadcrumbOptions.cs
@@ -2,7 +2,6 @@
 {
     public class BreadcrumbOptions
     {
-
         #region Properties
 
         /// <summary>
@@ -72,7 +71,13 @@
         /// </summary>
         public bool FallbackTitleToMethodName { get; set; }
 
-        #endregion
+        /// <summary>
+        /// Application relative path used as the root of discovery for Razor Page files
+        /// Defaults to the /Pages directory under application root.
+        /// </summary>
+        public string RazorPagesRootDirectory { get; set; }
+
+        #endregion Properties
 
         public BreadcrumbOptions()
         {
@@ -83,11 +88,13 @@
             InferFromAction = true;
             DefaultAction = "Index";
             FallbackTitleToMethodName = true;
+            RazorPagesRootDirectory = "Pages";
         }
 
         public BreadcrumbOptions(string tagName, string olClasses, string liClasses,
             string activeLiClasses, string tagClasses = null, string separatorElement = null,
-            bool inferFromAction = true, string defaultAction = "Index", bool fallbackTitleToMethodName = true)
+            bool inferFromAction = true, string defaultAction = "Index", bool fallbackTitleToMethodName = true,
+            string razorPagesRootDirectory = "Pages")
         {
             TagName = tagName;
             OlClasses = olClasses;
@@ -98,7 +105,7 @@
             InferFromAction = inferFromAction;
             DefaultAction = defaultAction;
             FallbackTitleToMethodName = fallbackTitleToMethodName;
+            RazorPagesRootDirectory = razorPagesRootDirectory;
         }
-
     }
 }

--- a/src/BreadcrumbOptions.cs
+++ b/src/BreadcrumbOptions.cs
@@ -72,8 +72,8 @@
         public bool FallbackTitleToMethodName { get; set; }
 
         /// <summary>
-        /// Application relative path used as the root of discovery for Razor Page files
-        /// Defaults to the /Pages directory under application root.
+        /// Application path used as the root of discovery for Razor Page files.
+        /// Defaults to the "Pages" directory under application root.
         /// </summary>
         public string RazorPagesRootDirectory { get; set; }
 

--- a/src/Extensions/ReflectionExtensions.cs
+++ b/src/Extensions/ReflectionExtensions.cs
@@ -11,15 +11,14 @@ namespace SmartBreadcrumbs.Extensions
 {
     public static class ReflectionExtensions
     {
-
         #region Fields
 
         private static readonly Type PageModelType = typeof(PageModel);
         private static readonly Type ControllerType = typeof(Controller);
         private static readonly Type ActionResultType = typeof(IActionResult);
         private static readonly Type GenericTaskType = typeof(Task<>);
-        
-        #endregion
+
+        #endregion Fields
 
         public static bool IsController(this Type type)
             => type != null && ControllerType.IsAssignableFrom(type);
@@ -40,12 +39,14 @@ namespace SmartBreadcrumbs.Extensions
             if (pageType == null)
                 throw new ArgumentNullException(nameof(pageType));
 
-            string fullName = pageType.FullName;
-            int pagesIndex = fullName.IndexOf(".Pages.");
-            if (pagesIndex == -1)
-                throw new SmartBreadcrumbsException($"The full name {fullName} doesn't contain 'Pages'.");
+            string razorPagesRootDirectory = BreadcrumbManager.Options.RazorPagesRootDirectory;
 
-            int startIndex = pagesIndex + 6;
+            string fullName = pageType.FullName;
+            int pagesIndex = fullName.IndexOf($".{razorPagesRootDirectory}.");
+            if (pagesIndex == -1)
+                throw new SmartBreadcrumbsException($"The full name {fullName} doesn't contain '{razorPagesRootDirectory}'.");
+
+            int startIndex = pagesIndex + razorPagesRootDirectory.Length + 1;
             int endIndex = fullName.EndsWith("Model") ? fullName.Length - 5 : fullName.Length;
             return fullName.Substring(startIndex, endIndex - startIndex).Replace('.', '/');
         }

--- a/tests/SmartBreadcrumbs.UnitTests/Features/FeatureOne/SubFeatureModel.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/Features/FeatureOne/SubFeatureModel.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace SmartBreadcrumbs.UnitTests.Features.FeatureOne
+{
+    public class SubFeatureModel : PageModel
+    {
+    }
+}

--- a/tests/SmartBreadcrumbs.UnitTests/Features/Orders.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/Features/Orders.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace SmartBreadcrumbs.UnitTests.Features
+{
+    public class Orders : PageModel
+    {
+    }
+}

--- a/tests/SmartBreadcrumbs.UnitTests/Features/ProductsModel.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/Features/ProductsModel.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace SmartBreadcrumbs.UnitTests.Features
+{
+    public class ProductsModel : PageModel
+    {
+    }
+}

--- a/tests/SmartBreadcrumbs.UnitTests/ReflectionExtensionsTests.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/ReflectionExtensionsTests.cs
@@ -84,21 +84,7 @@ namespace SmartBreadcrumbs.UnitTests
         public void ExtractRazorPageKey_ShouldReturnCorrectPath_WhenDefaultRazorPagesRootDirectoryIsPages(Type type, string expectedPath)
         {
             Assert.Equal(expectedPath, type.ExtractRazorPageKey());
-        }
-
-        [Theory]
-        [InlineData(typeof(Orders), "/Orders")]        
-        [InlineData(typeof(ProductsModel), "/Products")]
-        [InlineData(typeof(SubFeatureModel), "/FeatureOne/SubFeature")]
-        public void ExtractRazorPageKey_ShouldReturnCorrectPath_WhenRazorPagesRootDirectoryIsModified(Type type, string expectedPath)
-        {
-            var bm = new BreadcrumbManager(new BreadcrumbOptions { 
-                RazorPagesRootDirectory = "Features"
-            });
-            bm.Initialize(GetType().Assembly);
-
-            Assert.Equal(expectedPath, type.ExtractRazorPageKey());
-        }
+        }        
 
         #endregion ExtractRazorPageKey
 
@@ -148,5 +134,27 @@ namespace SmartBreadcrumbs.UnitTests
         }
 
         #endregion ExtractMvcKey
+
+        public class ReflectionExtensionsTests_ModifiedRazorPagesRootDirectory : IDisposable
+        {
+            public ReflectionExtensionsTests_ModifiedRazorPagesRootDirectory()
+            {
+                BreadcrumbManager.Options.RazorPagesRootDirectory = "Features";
+            }
+
+            public void Dispose()
+            {
+                BreadcrumbManager.Options.RazorPagesRootDirectory = "Pages";
+            }
+
+            [Theory]
+            [InlineData(typeof(Orders), "/Orders")]
+            [InlineData(typeof(ProductsModel), "/Products")]
+            [InlineData(typeof(SubFeatureModel), "/FeatureOne/SubFeature")]
+            public void ExtractRazorPageKey_ShouldReturnCorrectPath_WhenRazorPagesRootDirectoryIsModified(Type type, string expectedPath)
+            {
+                Assert.Equal(expectedPath, type.ExtractRazorPageKey());
+            }
+        }
     }
 }

--- a/tests/SmartBreadcrumbs.UnitTests/ReflectionExtensionsTests.cs
+++ b/tests/SmartBreadcrumbs.UnitTests/ReflectionExtensionsTests.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using SmartBreadcrumbs.Controllers.SubFolder;
 using SmartBreadcrumbs.Extensions;
+using SmartBreadcrumbs.UnitTests.Features;
+using SmartBreadcrumbs.UnitTests.Features.FeatureOne;
 using SmartBreadcrumbs.UnitTests.Pages;
 using SmartBreadcrumbs.UnitTests.Pages.SubFolder1;
 using Xunit;
@@ -14,7 +14,6 @@ namespace SmartBreadcrumbs.UnitTests
 {
     public class ReflectionExtensionsTests
     {
-
         #region IsController
 
         [Theory]
@@ -26,7 +25,7 @@ namespace SmartBreadcrumbs.UnitTests
             Assert.Equal(expected, type.IsController());
         }
 
-        #endregion
+        #endregion IsController
 
         #region IsRazorPage
 
@@ -39,7 +38,7 @@ namespace SmartBreadcrumbs.UnitTests
             Assert.Equal(expected, type.IsRazorPage());
         }
 
-        #endregion
+        #endregion IsRazorPage
 
         #region IsAction
 
@@ -58,7 +57,7 @@ namespace SmartBreadcrumbs.UnitTests
             Assert.Equal(expected, type.IsAction());
         }
 
-        #endregion
+        #endregion IsAction
 
         #region ExtractRazorPageKey
 
@@ -70,7 +69,7 @@ namespace SmartBreadcrumbs.UnitTests
         }
 
         [Fact]
-        public void ExtractRazorPageKey_ShouldThrowSmartBreadcrumbsException_WhenFullNameDoesntContainPages()
+        public void ExtractRazorPageKey_ShouldThrowSmartBreadcrumbsException_WhenDefaultRazorPagesRootDirectoryIsPages()
         {
             var type = typeof(TestClassThree);
             var ex = Assert.Throws<SmartBreadcrumbsException>(() => type.ExtractRazorPageKey());
@@ -82,12 +81,26 @@ namespace SmartBreadcrumbs.UnitTests
         [InlineData(typeof(TestClassTwo), "/TestClassTwo")]
         [InlineData(typeof(SomePage1Model), "/SomePage1")]
         [InlineData(typeof(SomeModelPageModel), "/SomeModelPage")]
-        public void ExtractRazorPageKey_ShouldReturnCorrectPath(Type type, string expectedPath)
+        public void ExtractRazorPageKey_ShouldReturnCorrectPath_WhenDefaultRazorPagesRootDirectoryIsPages(Type type, string expectedPath)
         {
             Assert.Equal(expectedPath, type.ExtractRazorPageKey());
         }
 
-        #endregion
+        [Theory]
+        [InlineData(typeof(Orders), "/Orders")]        
+        [InlineData(typeof(ProductsModel), "/Products")]
+        [InlineData(typeof(SubFeatureModel), "/FeatureOne/SubFeature")]
+        public void ExtractRazorPageKey_ShouldReturnCorrectPath_WhenRazorPagesRootDirectoryIsModified(Type type, string expectedPath)
+        {
+            var bm = new BreadcrumbManager(new BreadcrumbOptions { 
+                RazorPagesRootDirectory = "Features"
+            });
+            bm.Initialize(GetType().Assembly);
+
+            Assert.Equal(expectedPath, type.ExtractRazorPageKey());
+        }
+
+        #endregion ExtractRazorPageKey
 
         #region ExtractMvcControllerKey
 
@@ -107,7 +120,7 @@ namespace SmartBreadcrumbs.UnitTests
             Assert.Equal($"{expectedKey}.{defaultAction}", fromController.ExtractMvcControllerKey());
         }
 
-        #endregion
+        #endregion ExtractMvcControllerKey
 
         #region ExtractMvcKey
 
@@ -134,7 +147,6 @@ namespace SmartBreadcrumbs.UnitTests
             Assert.Equal(expectedKey, fromController.ExtractMvcKey(actionMethod));
         }
 
-        #endregion
-
+        #endregion ExtractMvcKey
     }
 }


### PR DESCRIPTION
In reference to issue [#56 ](https://github.com/zHaytam/SmartBreadcrumbs/issues/56), one use case that results to changing the default razor pages root directory if a project is utilizing [FeatureFolders ](https://github.com/OdeToCode/AddFeatureFolders) and then the razor pages root directory is also changed to use Features folder.

```
services.AddRazorPages(options =>
{
    options.RootDirectory = "/Features";
});
```

Now we can set which root directory SmartBreadcrumbs is used through BreadcrumbOptions

```
services.AddBreadcrumbs(Assembly.GetExecutingAssembly(), options =>
{
    options.RazorPagesRootDirectory = "Features";
});
```