### PR TITLE
Added optional support for IHtmlContent titles

### DIFF
--- a/src/BreadcrumbOptions.cs
+++ b/src/BreadcrumbOptions.cs
@@ -89,6 +89,11 @@ namespace SmartBreadcrumbs
         /// </summary>
         public Type ResourceType { get; set; }
 
+        /// <summary>
+        /// Set to true if you want to allow IHtmlContent ViewData values to be written as raw HTML
+        /// </summary>
+        public bool AllowHtmlContent { get; set; }
+
         #endregion Properties
 
         public BreadcrumbOptions()


### PR DESCRIPTION
I thought it could be useful to support having an IHtmlContent instance in a ViewData-derived title to allow non-encoded HTML labels.
I think instancing a TextWriter is wasteful but I didn't want to change the class structure too much to use the ProcessAsync StringBuilder instance directly.